### PR TITLE
Map personal administrative number from Keycloak

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@
 ktlint_code_style = ktlint_official
 ktlint_standard_no-wildcard-imports = disabled
 ktlint_standard_multiline-if-else = disabled
+indent_style = space

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,7 +137,6 @@ springBoot {
 tasks.named<BootBuildImage>("bootBuildImage") {
     imageName.set("$group/${project.name}")
     publish.set(false)
-    environment.set(System.getenv())
     val env = environment.get()
     docker {
         publishRegistry {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerContext.kt
@@ -401,7 +401,7 @@ fun beans(clock: Clock) = BeanRegistrarDsl {
     registerBean {
         val keycloakProperties = bean<KeycloakConfigurationProperties>()
         GetPidDataFromKeyCloak(
-            KeycloakClient(
+            SpringKeycloakClient(
                 webClient,
                 keyCloak = Url(keycloakProperties.serverUrl.toExternalForm()),
                 AdministrationClient(

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/IssuerContext.kt
@@ -401,17 +401,19 @@ fun beans(clock: Clock) = BeanRegistrarDsl {
     registerBean {
         val keycloakProperties = bean<KeycloakConfigurationProperties>()
         GetPidDataFromKeyCloak(
+            KeycloakClient(
+                webClient,
+                keyCloak = Url(keycloakProperties.serverUrl.toExternalForm()),
+                AdministrationClient(
+                    realm = Realm(keycloakProperties.authenticationRealm),
+                    client = Credentials(username = keycloakProperties.clientId, password = null),
+                    admin = Credentials(username = keycloakProperties.username, password = keycloakProperties.password),
+                ),
+                users = Realm(keycloakProperties.userRealm)
+            ),
             issuerCountry = env.getRequiredProperty("issuer.pid.issuingCountry").let(::IsoCountry),
             issuingJurisdiction = env.getProperty("issuer.pid.issuingJurisdiction"),
-            clock = clock,
-            webClient = bean(),
-            keyCloak = Url(keycloakProperties.serverUrl.toExternalForm()),
-            administrationClient = AdministrationClient(
-                realm = Realm(keycloakProperties.authenticationRealm),
-                client = Credentials(username = keycloakProperties.clientId, password = null),
-                admin = Credentials(username = keycloakProperties.username, password = keycloakProperties.password),
-            ),
-            users = Realm(keycloakProperties.userRealm),
+            clock = clock
         )
     }
     registerBean<EncodePidInCbor>(lazyInit = true) {

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
@@ -16,58 +16,23 @@
 package eu.europa.ec.eudi.pidissuer.adapter.out.pid
 
 import arrow.core.nonEmptyListOf
-import com.nimbusds.oauth2.sdk.token.AccessToken
-import com.nimbusds.oauth2.sdk.util.JSONObjectUtils
 import eu.europa.ec.eudi.pidissuer.adapter.out.oauth.OidcAssurancePlaceOfBirth
 import eu.europa.ec.eudi.pidissuer.adapter.out.util.loadResource
 import eu.europa.ec.eudi.pidissuer.domain.Clock
 import eu.europa.ec.eudi.pidissuer.port.input.Username
 import io.ktor.http.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.datetime.LocalDate
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.reactive.function.BodyInserters
-import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBody
 import java.util.*
 import kotlin.time.Duration.Companion.days
 
 private val log = LoggerFactory.getLogger(GetPidDataFromKeyCloak::class.java)
 
-data class Credentials(val username: String, val password: String?) {
-    init {
-        require(username.isNotBlank()) { "username cannot be blank" }
-    }
-}
-
-@JvmInline
-value class Realm(val value: String) {
-    init {
-        require(value.isNotBlank()) { "realm cannot be blank" }
-    }
-}
-
-data class AdministrationClient(
-    val realm: Realm,
-    val client: Credentials,
-    val admin: Credentials,
-)
-
 class GetPidDataFromKeyCloak(
+    private val keyCloakClient: KeycloakClient,
     private val issuerCountry: IsoCountry,
     private val issuingJurisdiction: IsoCountrySubdivision?,
     private val clock: Clock,
-    private val webClient: WebClient,
-    private val keyCloak: Url,
-    private val administrationClient: AdministrationClient,
-    private val users: Realm,
 ) : GetPidData {
     init {
         issuingJurisdiction?.let {
@@ -129,7 +94,7 @@ class GetPidDataFromKeyCloak(
             } else null
         }
 
-        return getUserByUsername(username)
+        return keyCloakClient.getUserByUsername(username)
             ?.let { user ->
                 UserInfo(
                     familyName = user.lastName,
@@ -147,70 +112,6 @@ class GetPidDataFromKeyCloak(
                     nationality = user.attributes["nationality"]?.firstOrNull(),
                 )
             }
-    }
-
-    /**
-     * Fetches the details of a user.
-     *
-     * @param username The username of the user the details of whose to fetch
-     */
-    private suspend fun getUserByUsername(username: String): UserRepresentation? {
-        val accessToken = getAdminAccessToken()
-        val url = URLBuilder()
-            .takeFrom(keyCloak)
-            .appendPathSegments("admin", "realms", users.value, "users")
-            .apply {
-                parameters.append("username", username)
-                parameters.append("exact", "true")
-            }
-            .build()
-
-        val users = webClient.get()
-            .uri(url.toURI())
-            .accept(MediaType.APPLICATION_JSON)
-            .headers {
-                it[HttpHeaders.AUTHORIZATION] = accessToken.toAuthorizationHeader()
-            }
-            .retrieve()
-            .awaitBody<List<UserRepresentation>>()
-
-        return if (users.size != 1) {
-            null
-        } else {
-            users.first()
-        }
-    }
-
-    /**
-     * Gets an Access Token for the Admin user, using OAuth2.0 Password Grant.
-     */
-    private suspend fun getAdminAccessToken(): AccessToken {
-        val tokenEndpoint = URLBuilder()
-            .takeFrom(keyCloak)
-            .appendPathSegments("realms", administrationClient.realm.value, "protocol", "openid-connect", "token")
-            .build()
-        val response = webClient.post()
-            .uri(tokenEndpoint.toURI())
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-            .accept(MediaType.APPLICATION_JSON)
-            .body(
-                BodyInserters.fromFormData(
-                    LinkedMultiValueMap<String, String>()
-                        .apply {
-                            add("grant_type", "password")
-                            add("client_id", administrationClient.client.username)
-                            administrationClient.client.password?.let { add("client_secret", it) }
-                            add("username", administrationClient.admin.username)
-                            administrationClient.admin.password?.let { add("password", it) }
-                        },
-                ),
-            )
-            .retrieve()
-            .awaitBody<String>()
-
-        return withContext(Dispatchers.Default) {
-            AccessToken.parse(JSONObjectUtils.parse(response))
-        }
     }
 
     private fun genPidMetaData(): PidMetaData {
@@ -277,16 +178,6 @@ class GetPidDataFromKeyCloak(
         return pid to pidMetaData
     }
 }
-
-@Serializable
-@JsonIgnoreUnknownKeys
-data class UserRepresentation(
-    @Required val username: String,
-    @Required val lastName: String,
-    @Required val firstName: String,
-    val attributes: Map<String, List<String>> = emptyMap(),
-    val email: String? = null,
-)
 
 private data class UserInfo(
     val familyName: String,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
@@ -29,7 +29,7 @@ import kotlin.time.Duration.Companion.days
 private val log = LoggerFactory.getLogger(GetPidDataFromKeyCloak::class.java)
 
 class GetPidDataFromKeyCloak(
-    private val keyCloakClient: SpringKeycloakClient,
+    private val keyCloakClient: KeycloakClient,
     private val issuerCountry: IsoCountry,
     private val issuingJurisdiction: IsoCountrySubdivision?,
     private val clock: Clock,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
@@ -29,7 +29,7 @@ import kotlin.time.Duration.Companion.days
 private val log = LoggerFactory.getLogger(GetPidDataFromKeyCloak::class.java)
 
 class GetPidDataFromKeyCloak(
-    private val keyCloakClient: KeycloakClient,
+    private val keyCloakClient: SpringKeycloakClient,
     private val issuerCountry: IsoCountry,
     private val issuingJurisdiction: IsoCountrySubdivision?,
     private val clock: Clock,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloak.kt
@@ -97,6 +97,7 @@ class GetPidDataFromKeyCloak(
         return keyCloakClient.getUserByUsername(username)
             ?.let { user ->
                 UserInfo(
+                    personalAdministrativeNumber = user.attributes["personal_administrative_number"]?.firstOrNull(),
                     familyName = user.lastName,
                     givenName = user.firstName,
                     birthFamilyName = user.attributes["birth_family_name"]?.firstOrNull(),
@@ -114,14 +115,16 @@ class GetPidDataFromKeyCloak(
             }
     }
 
-    private fun genPidMetaData(): PidMetaData {
+    private fun genPidMetaData(userInfo: UserInfo): PidMetaData {
         val (issuanceDate, expiryDate) = with(clock) {
             val now = now()
             now.toLocalDate() to (now + 100.days).toLocalDate()
         }
 
         return PidMetaData(
-            personalAdministrativeNumber = AdministrativeNumber(UUID.randomUUID().toString()),
+            personalAdministrativeNumber = AdministrativeNumber(
+                    userInfo.personalAdministrativeNumber ?: UUID.randomUUID().toString()
+            ),
             expiryDate = expiryDate,
             issuingAuthority = IssuingAuthority.AdministrativeAuthority("${issuerCountry.value} Administrative authority"),
             issuingCountry = issuerCountry,
@@ -173,13 +176,14 @@ class GetPidDataFromKeyCloak(
             mobilePhoneNumber = null,
         )
 
-        val pidMetaData = genPidMetaData()
+        val pidMetaData = genPidMetaData(userInfo)
 
         return pid to pidMetaData
     }
 }
 
 private data class UserInfo(
+    val personalAdministrativeNumber: String?,
     val familyName: String,
     val givenName: String,
     val birthFamilyName: String? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/KeycloakClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/KeycloakClient.kt
@@ -1,0 +1,24 @@
+package eu.europa.ec.eudi.pidissuer.adapter.out.pid
+
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+
+interface KeycloakClient {
+    /**
+     * Fetches the details of a user.
+     *
+     * @param username The username of the user the details of whose to fetch
+     */
+    suspend fun getUserByUsername(username: String): UserRepresentation?
+}
+
+@Serializable
+@JsonIgnoreUnknownKeys
+data class UserRepresentation(
+    @Required val username: String,
+    @Required val lastName: String,
+    @Required val firstName: String,
+    val attributes: Map<String, List<String>> = emptyMap(),
+    val email: String? = null,
+)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/KeycloakClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/KeycloakClient.kt
@@ -1,0 +1,121 @@
+package eu.europa.ec.eudi.pidissuer.adapter.out.pid
+
+import com.nimbusds.oauth2.sdk.token.AccessToken
+import com.nimbusds.oauth2.sdk.util.JSONObjectUtils
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.appendPathSegments
+import io.ktor.http.takeFrom
+import io.ktor.http.toURI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+
+data class Credentials(val username: String, val password: String?) {
+    init {
+        require(username.isNotBlank()) { "username cannot be blank" }
+    }
+}
+
+@JvmInline
+value class Realm(val value: String) {
+    init {
+        require(value.isNotBlank()) { "realm cannot be blank" }
+    }
+}
+
+data class AdministrationClient(
+    val realm: Realm,
+    val client: Credentials,
+    val admin: Credentials,
+)
+
+class KeycloakClient(
+    val webClient: WebClient,
+    val keyCloak: Url,
+    val administrationClient: AdministrationClient,
+    val users: Realm
+) {
+
+    /**
+     * Fetches the details of a user.
+     *
+     * @param username The username of the user the details of whose to fetch
+     */
+    suspend fun getUserByUsername(username: String): UserRepresentation? {
+        val accessToken = getAdminAccessToken()
+        val url = URLBuilder()
+            .takeFrom(keyCloak)
+            .appendPathSegments("admin", "realms", users.value, "users")
+            .apply {
+                parameters.append("username", username)
+                parameters.append("exact", "true")
+            }
+            .build()
+
+        val users = webClient.get()
+            .uri(url.toURI())
+            .accept(MediaType.APPLICATION_JSON)
+            .headers {
+                it[HttpHeaders.AUTHORIZATION] = accessToken.toAuthorizationHeader()
+            }
+            .retrieve()
+            .awaitBody<List<UserRepresentation>>()
+
+        return if (users.size != 1) {
+            null
+        } else {
+            users.first()
+        }
+    }
+
+    /**
+     * Gets an Access Token for the Admin user, using OAuth2.0 Password Grant.
+     */
+    private suspend fun getAdminAccessToken(): AccessToken {
+        val tokenEndpoint = URLBuilder()
+            .takeFrom(keyCloak)
+            .appendPathSegments("realms", administrationClient.realm.value, "protocol", "openid-connect", "token")
+            .build()
+        val response = webClient.post()
+            .uri(tokenEndpoint.toURI())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .accept(MediaType.APPLICATION_JSON)
+            .body(
+                BodyInserters.fromFormData(
+                    LinkedMultiValueMap<String, String>()
+                        .apply {
+                            add("grant_type", "password")
+                            add("client_id", administrationClient.client.username)
+                            administrationClient.client.password?.let { add("client_secret", it) }
+                            add("username", administrationClient.admin.username)
+                            administrationClient.admin.password?.let { add("password", it) }
+                        },
+                ),
+            )
+            .retrieve()
+            .awaitBody<String>()
+
+        return withContext(Dispatchers.Default) {
+            AccessToken.parse(JSONObjectUtils.parse(response))
+        }
+    }
+}
+
+@Serializable
+@JsonIgnoreUnknownKeys
+data class UserRepresentation(
+    @Required val username: String,
+    @Required val lastName: String,
+    @Required val firstName: String,
+    val attributes: Map<String, List<String>> = emptyMap(),
+    val email: String? = null,
+)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/SpringKeycloakClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/SpringKeycloakClient.kt
@@ -9,9 +9,6 @@ import io.ktor.http.takeFrom
 import io.ktor.http.toURI
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.util.LinkedMultiValueMap
@@ -43,14 +40,14 @@ class SpringKeycloakClient(
     val keyCloak: Url,
     val administrationClient: AdministrationClient,
     val users: Realm
-) {
+) : KeycloakClient {
 
     /**
      * Fetches the details of a user.
      *
      * @param username The username of the user the details of whose to fetch
      */
-    suspend fun getUserByUsername(username: String): UserRepresentation? {
+    override suspend fun getUserByUsername(username: String): UserRepresentation? {
         val accessToken = getAdminAccessToken()
         val url = URLBuilder()
             .takeFrom(keyCloak)
@@ -109,13 +106,3 @@ class SpringKeycloakClient(
         }
     }
 }
-
-@Serializable
-@JsonIgnoreUnknownKeys
-data class UserRepresentation(
-    @Required val username: String,
-    @Required val lastName: String,
-    @Required val firstName: String,
-    val attributes: Map<String, List<String>> = emptyMap(),
-    val email: String? = null,
-)

--- a/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/SpringKeycloakClient.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/SpringKeycloakClient.kt
@@ -38,7 +38,7 @@ data class AdministrationClient(
     val admin: Credentials,
 )
 
-class KeycloakClient(
+class SpringKeycloakClient(
     val webClient: WebClient,
     val keyCloak: Url,
     val administrationClient: AdministrationClient,

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloakTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloakTest.kt
@@ -1,0 +1,58 @@
+package eu.europa.ec.eudi.pidissuer.adapter.out.pid
+
+
+import arrow.core.nonEmptyListOf
+import eu.europa.ec.eudi.pidissuer.domain.Clock
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.mock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+internal class GetPidDataFromKeyCloakTest {
+    @Test
+    internal fun `maps minimal data from Keycloak`() = runTest {
+        val client: KeycloakClient = mock(KeycloakClient::class.java)
+        given(client.getUserByUsername("user")).willReturn(
+            UserRepresentation(
+                "tneal", "Neal", "Tyler", mapOf(
+                    Pair("birthdate", listOf("1955-04-12"))
+                )
+            )
+        )
+
+        val (pid, _) = checkNotNull(
+            GetPidDataFromKeyCloak(
+                keyCloakClient = client,
+                issuerCountry = IsoCountry("GR"),
+                issuingJurisdiction = "GR-I",
+                clock = Clock.fixed(Instant.parse("2026-01-01T12:39:44Z"), TimeZone.UTC)
+            ).invoke("user")
+        )
+
+        assertEquals(FamilyName("Neal"), pid.familyName)
+        assertEquals(GivenName("Tyler"), pid.givenName)
+        assertEquals(LocalDate.parse("1955-04-12", LocalDate.Formats.ISO), pid.birthDate)
+        assertEquals(PlaceOfBirth(locality = City("Not known")), pid.placeOfBirth)
+        assertEquals(nonEmptyListOf(Nationality("GR")), pid.nationalities)
+        assertNotNull(pid.portrait)
+
+        assertNull(pid.residentAddress)
+        assertNull(pid.residentCountry)
+        assertNull(pid.residentState)
+        assertNull(pid.residentCity)
+        assertNull(pid.residentPostalCode)
+        assertNull(pid.residentStreet)
+        assertNull(pid.residentHouseNumber)
+        assertNull(pid.familyNameBirth)
+        assertNull(pid.givenNameBirth)
+        assertNull(pid.sex)
+        assertNull(pid.emailAddress)
+        assertNull(pid.mobilePhoneNumber)
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloakTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloakTest.kt
@@ -15,25 +15,23 @@ import kotlin.test.assertNull
 import kotlin.time.Instant
 
 internal class GetPidDataFromKeyCloakTest {
+    val client: KeycloakClient = mock(KeycloakClient::class.java)
+    val minimalUser = UserRepresentation(
+        "tneal", "Neal", "Tyler", mapOf(
+            Pair("birthdate", listOf("1955-04-12"))
+        )
+    )
+    val function = GetPidDataFromKeyCloak(
+        keyCloakClient = client,
+        issuerCountry = IsoCountry("GR"),
+        issuingJurisdiction = "GR-I",
+        clock = Clock.fixed(Instant.parse("2026-01-01T12:39:44Z"), TimeZone.UTC)
+    )
+
     @Test
     internal fun `maps minimal data from Keycloak`() = runTest {
-        val client: KeycloakClient = mock(KeycloakClient::class.java)
-        given(client.getUserByUsername("user")).willReturn(
-            UserRepresentation(
-                "tneal", "Neal", "Tyler", mapOf(
-                    Pair("birthdate", listOf("1955-04-12"))
-                )
-            )
-        )
-
-        val (pid, _) = checkNotNull(
-            GetPidDataFromKeyCloak(
-                keyCloakClient = client,
-                issuerCountry = IsoCountry("GR"),
-                issuingJurisdiction = "GR-I",
-                clock = Clock.fixed(Instant.parse("2026-01-01T12:39:44Z"), TimeZone.UTC)
-            ).invoke("user")
-        )
+        given(client.getUserByUsername("user")).willReturn(minimalUser)
+        val (pid, _) = checkNotNull(function.invoke("user"))
 
         assertEquals(FamilyName("Neal"), pid.familyName)
         assertEquals(GivenName("Tyler"), pid.givenName)
@@ -58,12 +56,8 @@ internal class GetPidDataFromKeyCloakTest {
 
     @Test
     internal fun `maps all data from Keycloak`() = runTest {
-        val client: KeycloakClient = mock(KeycloakClient::class.java)
         given(client.getUserByUsername("user")).willReturn(
-            UserRepresentation(
-                username = "tneal",
-                lastName = "Neal",
-                firstName = "Tyler",
+            minimalUser.copy(
                 email = "tyler.neal@example.com",
                 attributes = mapOf(
                     Pair("birthdate", listOf("1955-04-12")),
@@ -85,14 +79,7 @@ internal class GetPidDataFromKeyCloakTest {
             )
         )
 
-        val (pid, _) = checkNotNull(
-            GetPidDataFromKeyCloak(
-                keyCloakClient = client,
-                issuerCountry = IsoCountry("GR"),
-                issuingJurisdiction = "GR-I",
-                clock = Clock.fixed(Instant.parse("2026-01-01T12:39:44Z"), TimeZone.UTC)
-            ).invoke("user")
-        )
+        val (pid, _) = checkNotNull(function.invoke("user"))
 
         assertEquals(FamilyName("Neal"), pid.familyName)
         assertEquals(GivenName("Tyler"), pid.givenName)

--- a/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloakTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/pidissuer/adapter/out/pid/GetPidDataFromKeyCloakTest.kt
@@ -55,4 +55,66 @@ internal class GetPidDataFromKeyCloakTest {
         assertNull(pid.emailAddress)
         assertNull(pid.mobilePhoneNumber)
     }
+
+    @Test
+    internal fun `maps all data from Keycloak`() = runTest {
+        val client: KeycloakClient = mock(KeycloakClient::class.java)
+        given(client.getUserByUsername("user")).willReturn(
+            UserRepresentation(
+                username = "tneal",
+                lastName = "Neal",
+                firstName = "Tyler",
+                email = "tyler.neal@example.com",
+                attributes = mapOf(
+                    Pair("birthdate", listOf("1955-04-12")),
+                    Pair("formatted", listOf("Trauner")),
+                    Pair("country", listOf("AT")),
+                    Pair("region", listOf("Lower Austria")),
+                    Pair("locality", listOf("Gemeinde Biberbach")),
+                    Pair("postal_code", listOf("3331")),
+                    Pair("street", listOf("Trauner")),
+                    Pair("address_house_number", listOf("101")),
+                    Pair("birth_family_name", listOf("Neal")),
+                    Pair("birth_given_name", listOf("Tyler")),
+                    Pair("birth_place", listOf("101 Trauner")),
+                    Pair("birth_country", listOf("AT")),
+                    Pair("birth_state", listOf("Lower Austria")),
+                    Pair("birth_city", listOf("Gemeinde Biberbach")),
+                    Pair("gender", listOf("1")),
+                )
+            )
+        )
+
+        val (pid, _) = checkNotNull(
+            GetPidDataFromKeyCloak(
+                keyCloakClient = client,
+                issuerCountry = IsoCountry("GR"),
+                issuingJurisdiction = "GR-I",
+                clock = Clock.fixed(Instant.parse("2026-01-01T12:39:44Z"), TimeZone.UTC)
+            ).invoke("user")
+        )
+
+        assertEquals(FamilyName("Neal"), pid.familyName)
+        assertEquals(GivenName("Tyler"), pid.givenName)
+        assertEquals(LocalDate.parse("1955-04-12", LocalDate.Formats.ISO), pid.birthDate)
+        assertEquals(
+            PlaceOfBirth(
+                IsoCountry("AT"), State("Lower Austria"), City("101 Trauner")
+            ), pid.placeOfBirth
+        )
+        assertEquals(nonEmptyListOf(Nationality("GR")), pid.nationalities)
+        assertNotNull(pid.portrait)
+        assertEquals("Trauner", pid.residentAddress)
+        assertEquals(IsoCountry("AT"), pid.residentCountry)
+        assertEquals(State("Lower Austria"), pid.residentState)
+        assertEquals(City("Gemeinde Biberbach"), pid.residentCity)
+        assertEquals(PostalCode("3331"), pid.residentPostalCode)
+        assertEquals(Street("Trauner"), pid.residentStreet)
+        assertEquals("101", pid.residentHouseNumber)
+        assertEquals(FamilyName("Neal"), pid.familyNameBirth)
+        assertEquals(GivenName("Tyler"), pid.givenNameBirth)
+        assertEquals(IsoGender(1u), pid.sex)
+        assertEquals("tyler.neal@example.com", pid.emailAddress)
+        assertEquals(null, pid.mobilePhoneNumber)
+    }
 }


### PR DESCRIPTION
This is a proof of concept demonstrating how to map a personal administrative number from Keycloak into a PID. Currently there are no automated tests in this changeset. However, in diggsweden/wallet-ecosystem#169 we have an automated end-to-end test demonstrating a working scenario of issuing and presenting a PID where the personal administrative number comes from the user data in Keycloak.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
